### PR TITLE
🧪 [test improvement] Missing error test for non-existent path in scan_for_old_files

### DIFF
--- a/sys-cleaner/cleaner.sh
+++ b/sys-cleaner/cleaner.sh
@@ -427,4 +427,6 @@ main() {
 }
 
 # --- Script Entry Point ---
-main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/sys-cleaner/tests/test_cleaner.sh
+++ b/sys-cleaner/tests/test_cleaner.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Test suite for cleaner.sh
+
+# Source the script to test
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "$DIR/../cleaner.sh"
+
+test_scan_for_old_files_invalid_path() {
+    echo "Testing scan_for_old_files with non-existent path..."
+
+    local invalid_path="/tmp/this/path/does/not/exist/at/all/$(date +%s)"
+
+    # scan_for_old_files reads 3 inputs:
+    # 1. days_old
+    # 2. scan_path
+    # 3. excludes
+
+    # We provide:
+    # \n (empty for days_old default)
+    # $invalid_path (for scan_path)
+    # \n (empty for excludes default)
+
+    output=$(printf "\n${invalid_path}\n\n" | scan_for_old_files 2>&1)
+    exit_code=$?
+
+    if [ $exit_code -ne 1 ]; then
+        echo "❌ FAILED: Expected exit code 1, got $exit_code"
+        return 1
+    fi
+
+    # The output contains color codes, so we use wildcard matching
+    if [[ "$output" == *"[ERROR] The path '$invalid_path' does not exist or is not a directory."* ]]; then
+        echo "✅ PASSED"
+        return 0
+    else
+        echo "❌ FAILED: Error message not found in output."
+        echo "Output was: $output"
+        return 1
+    fi
+}
+
+# Run tests
+failed=0
+test_scan_for_old_files_invalid_path || failed=1
+
+if [ $failed -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
This PR improves the test coverage of the `sys-cleaner` utility by adding an automated test case for an error condition.

### 🎯 What:
Addressed the missing error test for non-existent paths in the `scan_for_old_files` function.

### 📊 Coverage:
- Verified that `scan_for_old_files` returns exit code `1` when a non-existent path is provided.
- Verified that the correct error message is displayed: `[ERROR] The path '...' does not exist or is not a directory.`
- Refactored the script to allow sourcing of functions for testing without executing the main menu.

### ✨ Result:
Increased reliability of path validation in the `sys-cleaner` script. The new test ensures that the script handles invalid user input gracefully and as expected.

---
*PR created automatically by Jules for task [17657024287875207341](https://jules.google.com/task/17657024287875207341) started by @Cybonix*