### PR TITLE
Fix broken backup function and modernize grep usage

### DIFF
--- a/adminMenu.sh
+++ b/adminMenu.sh
@@ -30,7 +30,7 @@ two(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
                 read -s -p "Enter password : " password
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -eq 0 ]]; then
                         clear
                         echo -e "${RED}$username already exist!${STD}" && sleep 2
@@ -53,7 +53,7 @@ two(){
 three(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -ne 0 ]]; then
                         clear
                         echo -e "${RED}$username does not exist!${STD}" && sleep 2

--- a/backup
+++ b/backup
@@ -4,9 +4,16 @@
 
 # This function is not working...  I need to troubleshoot it.
 function backup () {
-	date_stamp=$(date "+%Y-%m-%d.%H%M.bak");
-	newname=$1.$date_stamp;
-	mv $1.$date_stamp $newname;
-	echo "Backed up $1.$date_stamp to $newname.";
-	cp -p $newname $1.$date_stamp;
+	if [[ -z "$1" ]]; then
+		echo "Usage: backup <filename>"
+		return 1
+	fi
+	local date_stamp=$(date "+%Y-%m-%d.%H%M.bak");
+	local newname="$1.$date_stamp";
+	cp -p "$1" "$newname";
+	echo "Backed up $1 to $newname.";
 }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	backup "$@"
+fi

--- a/tests/repro_backup.sh
+++ b/tests/repro_backup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Source the backup function
+source ./backup
+
+# Create a test file
+test_file="test_file.txt"
+echo "This is a test file." > "$test_file"
+
+echo "Attempting to backup $test_file..."
+backup "$test_file"
+
+if [ $? -eq 0 ]; then
+    echo "Backup function returned 0"
+else
+    echo "Backup function failed with exit code $?"
+fi
+
+# Check if backup exists
+# Expected newname format: test_file.txt.YYYY-MM-DD.HHMM.bak
+backup_file=$(ls test_file.txt.*.bak 2>/dev/null)
+
+if [ -n "$backup_file" ]; then
+    echo "Backup file created: $backup_file"
+else
+    echo "FAILED: Backup file not created"
+fi
+
+# Clean up
+rm -f "$test_file" "$backup_file"

--- a/wdw.sh
+++ b/wdw.sh
@@ -30,7 +30,7 @@ process_login() {
         home_dir=$(getent passwd $user | cut -d: -f6)
         history_file="$home_dir/.bash_history"
         if [ -f "$history_file" ]; then
-            egrep -i '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
+            grep -Ei '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
                 echo "|-- $command"
             done
         fi


### PR DESCRIPTION
The `backup` function was broken because it attempted to move a file using its intended backup name (which didn't exist yet) as the source. I've corrected this logic to properly copy the source file. I also took the opportunity to improve the script with input validation, local variables, and a source guard. Additionally, I updated other scripts in the repository to use `grep -E` instead of the deprecated `egrep`, consistent with the project's coding conventions.

---
*PR created automatically by Jules for task [12256696102089294724](https://jules.google.com/task/12256696102089294724) started by @Cybonix*