### PR TITLE
🧹 Refactor: replace deprecated egrep with grep -E

### DIFF
--- a/adminMenu.sh
+++ b/adminMenu.sh
@@ -30,7 +30,7 @@ two(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
                 read -s -p "Enter password : " password
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -eq 0 ]]; then
                         clear
                         echo -e "${RED}$username already exist!${STD}" && sleep 2
@@ -53,7 +53,7 @@ two(){
 three(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -ne 0 ]]; then
                         clear
                         echo -e "${RED}$username does not exist!${STD}" && sleep 2

--- a/wdw.sh
+++ b/wdw.sh
@@ -30,7 +30,7 @@ process_login() {
         home_dir=$(getent passwd $user | cut -d: -f6)
         history_file="$home_dir/.bash_history"
         if [ -f "$history_file" ]; then
-            egrep -i '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
+            grep -Ei '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
                 echo "|-- $command"
             done
         fi


### PR DESCRIPTION
🎯 **What:** Replaced deprecated `egrep` usage with `grep -E` in `adminMenu.sh` and `wdw.sh`.
💡 **Why:** `egrep` is officially deprecated in GNU grep. Replacing it with `grep -E` improves maintainability and ensures compatibility with modern grep standards without changing the script's behavior.
✅ **Verification:**
- Verified that all instances of `egrep` were replaced using `grep -r`.
- Performed syntax checks on modified files using `bash -n`.
- Confirmed that the regex patterns remain identical and functional.
✨ **Result:** The codebase is now free of deprecated `egrep` calls, aligning with modern shell scripting best practices.

---
*PR created automatically by Jules for task [4992360285115520628](https://jules.google.com/task/4992360285115520628) started by @Cybonix*