### PR TITLE
🔒 [security fix] Quote variables in system commands and replace deprecated egrep

### DIFF
--- a/adminMenu.sh
+++ b/adminMenu.sh
@@ -30,13 +30,13 @@ two(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
                 read -s -p "Enter password : " password
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -eq 0 ]]; then
                         clear
                         echo -e "${RED}$username already exist!${STD}" && sleep 2
                         pause
                 else
-                        pass=$(perl -e 'print crypt($ARGV[0], "password")' $password)
+                        pass=$(perl -e 'print crypt($ARGV[0], "password")' "$password")
                         useradd -m -p "$pass" "$username"
                         usermod -a -G wheel "$username"
                         clear
@@ -53,13 +53,13 @@ two(){
 three(){
         if [[ $(id -u) -eq 0 ]]; then
                 read -p "Enter username : " username
-                egrep "^$username" /etc/passwd >/dev/null
+                grep -E "^$username" /etc/passwd >/dev/null
                 if [[ $? -ne 0 ]]; then
                         clear
                         echo -e "${RED}$username does not exist!${STD}" && sleep 2
                         pause
                 else
-                        userdel -r $username && echo -e "${GREEN}$username has been deleted!${STD}" && sleep 2
+                        userdel -r "$username" && echo -e "${GREEN}$username has been deleted!${STD}" && sleep 2
                         pause
                 fi
         else

--- a/backup
+++ b/backup
@@ -5,8 +5,8 @@
 # This function is not working...  I need to troubleshoot it.
 function backup () {
 	date_stamp=$(date "+%Y-%m-%d.%H%M.bak");
-	newname=$1.$date_stamp;
-	mv $1.$date_stamp $newname;
+	newname="$1.$date_stamp";
+	mv "$1.$date_stamp" "$newname";
 	echo "Backed up $1.$date_stamp to $newname.";
-	cp -p $newname $1.$date_stamp;
+	cp -p "$newname" "$1.$date_stamp";
 }

--- a/backup.sh
+++ b/backup.sh
@@ -19,11 +19,11 @@ date
 echo
 
 # Backup the files using tar.
-tar czf $dest/$archive_file $backup_files
+tar czf "$dest/$archive_file" "$backup_files"
 
 # Print end status message.
 echo "Backup Finished with status $?"
 date
 
 # Long listing of files in $dest to check file sizes.
-ls -lh $dest
+ls -lh "$dest"

--- a/wdw.sh
+++ b/wdw.sh
@@ -27,10 +27,10 @@ process_login() {
         fi
 
         # Get the user's home directory and check if the history file exists and is readable
-        home_dir=$(getent passwd $user | cut -d: -f6)
+        home_dir=$(getent passwd "$user" | cut -d: -f6)
         history_file="$home_dir/.bash_history"
         if [ -f "$history_file" ]; then
-            egrep -i '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
+            grep -Ei '^(vi|nano|cat|less|more|tail|head|touch|rm|cp|mv|mkdir|rmdir|cd) ' "$history_file" | while read -r command; do
                 echo "|-- $command"
             done
         fi


### PR DESCRIPTION
🎯 **What:** Fixed multiple security vulnerabilities caused by unquoted variables in system commands and updated deprecated `egrep` usage.

⚠️ **Risk:** Unquoted variables in commands like `userdel`, `tar`, and `mv` can lead to word splitting and potential command injection if input (e.g., usernames or file paths) contains spaces or special characters. This could allow an attacker to manipulate system commands or cause data loss.

🛡️ **Solution:**
- Added double quotes around variables used as arguments to system commands across `adminMenu.sh`, `backup.sh`, `wdw.sh`, and the `backup` function script.
- Modernized the code by replacing `egrep` with `grep -E` (as per repository conventions).
- Verified the fixes using a test script that mocks system commands to ensure they receive arguments correctly when they contain spaces.

---
*PR created automatically by Jules for task [1711816845385774763](https://jules.google.com/task/1711816845385774763) started by @Cybonix*